### PR TITLE
ui: enlarge text on wallet support notice for readability

### DIFF
--- a/frontend/src/components/modals/UnsupportedWalletsNoticeModal.tsx
+++ b/frontend/src/components/modals/UnsupportedWalletsNoticeModal.tsx
@@ -1,10 +1,4 @@
-export const UnsupportedWalletsNoticeModal = ({
-  isOpen,
-  onClose,
-}: {
-  isOpen: boolean;
-  onClose: () => void;
-}) => {
+export const UnsupportedWalletsNoticeModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {
   if (!isOpen) return null;
 
   return (
@@ -28,9 +22,9 @@ export const UnsupportedWalletsNoticeModal = ({
         onClick={(e) => e.stopPropagation()}
         style={{
           backgroundColor: "rgb(18, 18, 18)",
-          padding: "30px",
+          padding: "50px",
           borderRadius: "8px",
-          maxWidth: "400px",
+          maxWidth: "500px",
           width: "90%",
           position: "relative",
         }}
@@ -38,31 +32,40 @@ export const UnsupportedWalletsNoticeModal = ({
         <div
           style={{
             fontWeight: "bold",
-            marginBottom: "15px",
-            fontSize: "18px",
+            marginBottom: "35px",
+            fontSize: "26px",
             color: "green",
+            lineHeight: "1.5",
           }}
         >
           Wallet Support Notice
         </div>
-        <div style={{ fontSize: "14px", color: "white", marginTop: "10px" }}>
-          Note: Gasless transactions are currently only supported for the Burner
-          wallet & Fuelet Wallet.
+        <div
+          style={{
+            fontSize: "18px",
+            color: "white",
+            marginTop: "25px",
+            lineHeight: "2",
+            letterSpacing: "0.4px",
+          }}
+        >
+          Note: Gasless transactions are currently only supported for the Burner wallet & Fuelet Wallet.
           <br />
           <br />
-          Support for other wallets is coming soon. If you use these other
-          wallets, you can still play the game by paying gas fees yourself.
+          Support for other wallets is coming soon. If you use these other wallets, you can still play the game by paying gas fees
+          yourself.
         </div>
         <button
           onClick={onClose}
           style={{
-            marginTop: "20px",
-            padding: "8px 16px",
+            marginTop: "40px",
+            padding: "14px 28px",
             borderRadius: "4px",
             border: "none",
             backgroundColor: "#102a9e",
             color: "#d0cdcd",
             cursor: "pointer",
+            fontSize: "18px",
           }}
         >
           Continue

--- a/frontend/src/components/modals/UnsupportedWalletsNoticeModal.tsx
+++ b/frontend/src/components/modals/UnsupportedWalletsNoticeModal.tsx
@@ -1,4 +1,10 @@
-export const UnsupportedWalletsNoticeModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {
+export const UnsupportedWalletsNoticeModal = ({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) => {
   if (!isOpen) return null;
 
   return (
@@ -49,11 +55,12 @@ export const UnsupportedWalletsNoticeModal = ({ isOpen, onClose }: { isOpen: boo
             letterSpacing: "0.4px",
           }}
         >
-          Note: Gasless transactions are currently only supported for the Burner wallet & Fuelet Wallet.
+          Note: Gasless transactions are currently only supported for the Burner
+          wallet & Fuelet Wallet.
           <br />
           <br />
-          Support for other wallets is coming soon. If you use these other wallets, you can still play the game by paying gas fees
-          yourself.
+          Support for other wallets is coming soon. If you use these other
+          wallets, you can still play the game by paying gas fees yourself.
         </div>
         <button
           onClick={onClose}


### PR DESCRIPTION
Previously the text was difficult to read

![image](https://github.com/user-attachments/assets/77d32516-40a6-401b-9f34-c9d07cc60413)


I've made it a bit larger and spread out the text

<img width="1229" alt="Screenshot 2024-12-18 at 8 41 25 AM" src="https://github.com/user-attachments/assets/bf8bc69c-38be-4d47-8740-06684086fea7" />
